### PR TITLE
Fix bad shell detection + dumb treatement of wa-cli.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.env
 /.vscode
 *.egg-info
-wa-cli.cfg
-/tools
+/wa_cli/wa-cli.cfg
+/wa_cli/tools

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@
 This has only been tested on Python 3.8.1 on OSX. I created a conda environment
 with that version running `conda env create -f environment.yml`.
 
-```
+<!-- markdownlint-disable MD014 -->
+```bash
 $ conda env create -f environment.yml
 $ conda activate wa-cli
 ```
@@ -48,15 +49,15 @@ $ conda activate wa-cli
 You can clone the repo or install directly from github. Once you have your
 virtual environment activated,
 
-**Cloning**
+* **Cloning**
 
-* Clone the repo
-* Switch to its folder
-* Run `pip install --editable .`
+  * Clone the repo
+  * Switch to its folder
+  * Run `pip install --editable .`
 
-**Direct installation**
+* Less tested alternative, **direct installation**
 
-Run `pip install https://github.com/xverges/wa-cli/archive/master.zip`
+  * Run `pip install https://github.com/xverges/wa-cli/archive/master.zip`
 
 ## Getting started
 
@@ -67,6 +68,8 @@ them as command line parameters.
 
 The `wa-cli` command provides help and command completion. Run `wa-cli env`
 to get the command that you have to execute to enable command completion
-and to set the variables that you provided when running `wa-cli init`
+and to set the variables that you provided when running `wa-cli init`. The
+specific command completion syntax depends on your default shell, as defined
+in `$SHELL`.
 
-https://github.com/xverges/wa-cli-demo demostrates the use of sanboxes
+<https://github.com/xverges/wa-cli-demo> demonstrates the use of sandboxes

--- a/wa_cli/commands/helpers/cfg.py
+++ b/wa_cli/commands/helpers/cfg.py
@@ -101,10 +101,11 @@ def write_file_contents(file_name, contents):
 
 
 def shell_completion():
+    shell = os.getenv('SHELL', '/bin/bash')
     source = 'source_bash'
-    if 'FISH_VERSION' in os.environ:
+    if 'fish' in shell:
         source = 'source_fish'
-    elif 'ZSH_VERSION' in os.environ:
+    elif 'zsh' in shell:
         source = 'source_zsh'
     return 'eval "$(_WA_CLI_COMPLETE=' + source + ' wa-cli)"'
 

--- a/wa_cli/commands/helpers/cfg.py
+++ b/wa_cli/commands/helpers/cfg.py
@@ -131,7 +131,8 @@ def get_project_folder() -> str:
 def get_code_folder() -> str:
     if not _cache['code_folder']:
         for folder in sys.path:
-            if os.path.isfile(os.path.join(folder, 'wa_cli', '__init__.py')):
+            folder = os.path.join(folder, 'wa_cli')
+            if os.path.isfile(os.path.join(folder, '__init__.py')):
                 folder = os.path.abspath(folder)
                 _cache['code_folder'] = folder
                 break


### PR DESCRIPTION
* While fixing #5, I noticed that `wa-cli.cfg` and the `tools` folder were placed in the wrong place (`.../site-packages`) when installing with `pip install https://...`.
* Fixed #6 by using `$SHELL`. While `echo $ZSH_VERSION` works, `env | grep ZSH` doe not. Go figure.